### PR TITLE
on accept(mimetype) makes tests fail if you don't specify an Accept header.

### DIFF
--- a/lib/cuba/ron.rb
+++ b/lib/cuba/ron.rb
@@ -209,7 +209,7 @@ module Cuba
     #   end
     def accept(mimetype)
       lambda do
-        env["HTTP_ACCEPT"].split(",").any? { |s| s.strip == mimetype } and
+        String(env["HTTP_ACCEPT"]).split(",").any? { |s| s.strip == mimetype } and
           res["Content-Type"] = mimetype
       end
     end

--- a/test/accept.rb
+++ b/test/accept.rb
@@ -14,3 +14,21 @@ test "accept mimetypes" do
 
   assert_equal ["application/xml"], resp.body
 end
+
+test "tests don't fail when you don't specify an accept type" do
+  Cuba.define do
+    on accept("application/xml") do
+      res.write res["Content-Type"]
+    end
+
+    on default do
+      res.write "Default action"
+    end
+  end
+
+  env = { "SCRIPT_NAME" => "/", "PATH_INFO" => "/post" }
+
+  _, _, resp = Cuba.call({})
+
+  assert_equal ["Default action"], resp.body
+end


### PR DESCRIPTION
If your app has on(accept(mimetype)), the tests will fail if you don't set an HTTP_ACCEPT, since Cuba::Ron expects it to be a string.
