### PR TITLE
Avoid deprecation warning when including Capybara for tests

### DIFF
--- a/lib/cuba/test.rb
+++ b/lib/cuba/test.rb
@@ -3,7 +3,11 @@ require "cutest"
 require "capybara/dsl"
 
 class Cutest::Scope
-  include Capybara
+  if defined? Capybara::DSL
+    include Capybara::DSL
+  else
+    include Capybara
+  end
 end
 
 Capybara.app = Cuba


### PR DESCRIPTION
Capybara 1.0.0 moved its DSL into a separated module, and gives the following warning when testing Cuba applications:

```
$ ruby -I../lib site_test.rb
`include Capybara` is deprecated please use `include Capybara::DSL` instead.
```
