### PR TITLE
Fix typo on README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Cuba.define do
 
   # only POST requests
   on post do
-    on "login"
+    on "login" do
 
       # POST /login, user: foo, pass: baz
       on param("user"), param("pass") do |user, pass|


### PR DESCRIPTION
I realize a missing `do` keyword in the matcher example on README page while I read the example for @codereading session.
