### PR TITLE
Only set response status to 200 if ever written to response.

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -7,7 +7,7 @@ class Cuba
 
     attr :headers
 
-    def initialize(status = 200,
+    def initialize(status = nil,
                    headers = { "Content-Type" => "text/html; charset=utf-8" })
 
       @status  = status
@@ -26,7 +26,7 @@ class Cuba
 
     def write(str)
       s = str.to_s
-
+      @status ||= 200
       @length += s.bytesize
       @headers["Content-Length"] = @length.to_s
       @body << s
@@ -38,7 +38,7 @@ class Cuba
     end
 
     def finish
-      [@status, @headers, @body]
+      [@status || 404, @headers, @body]
     end
 
     def set_cookie(key, value)

--- a/test/on.rb
+++ b/test/on.rb
@@ -95,3 +95,25 @@ test "reverts a half-met matcher" do
   assert_equal "/post", env["PATH_INFO"]
   assert_equal "/", env["SCRIPT_NAME"]
 end
+
+test "responds 404 if block never wrote to response" do
+  Cuba.define do
+    on get do
+      on "hello" do
+        res.write "world"
+      end
+    end
+  end
+
+  env = { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/hello",
+          "SCRIPT_NAME" => "/" }
+  status, _, resp = Cuba.call(env)
+  assert_equal 200, status
+  assert_response resp, ["world"]
+
+  env = { "REQUEST_METHOD" => "GET", "PATH_INFO" => "/",
+          "SCRIPT_NAME" => "/" }
+  status, _, resp = Cuba.call(env)
+  assert_equal 404, status
+  assert_response resp, []
+end


### PR DESCRIPTION
Cuba should not have have that "tricky behaviour" as stated on
the current README.md file.

If you have a Cuba app like:

``` ruby
on get do
  on "hello" do
    res.wirte "world"
  end
end
```

Content is only written for `GET /hello` so if you request
`GET /` Cuba shouldn't set the status code to 200 unless user
explicitly wrote something to the response or explicitly set
the response status to anything other than 404.

This commit makes a change to Cuba to set status 200 only then
a `res.write` is performed, having the status to fallback to 404.

I guess we should change the documentation to reflect this,
we could still use some of the examples on the README.md to
demo some of Cuba composition features, but having this status
issue fixed adheres to the principle of least astonishment.
