### PR TITLE
Add support for custom default layouts.

### DIFF
--- a/lib/cuba/render.rb
+++ b/lib/cuba/render.rb
@@ -5,13 +5,14 @@ class Cuba
     def self.setup(app)
       app.settings[:render] ||= {}
       app.settings[:render][:template_engine] ||= "erb"
+      app.settings[:render][:layout] ||= "layout"
       app.settings[:render][:views] ||= File.expand_path("views", Dir.pwd)
       app.settings[:render][:options] ||= {
         default_encoding: Encoding.default_external
       }
     end
 
-    def view(template, locals = {}, layout = "layout")
+    def view(template, locals = {}, layout = settings[:render][:layout])
       partial(layout, { content: partial(template, locals) }.merge(locals))
     end
 

--- a/test/render.rb
+++ b/test/render.rb
@@ -58,6 +58,14 @@ scope do
 
     assert_response body, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n\n"]
   end
+
+  test "custom default layout support" do
+    Cuba.settings[:render][:layout] = "layout-alternative"
+
+    _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
+
+    assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+  end
 end
 
 test "caching behavior" do
@@ -93,4 +101,19 @@ test "simple layout support" do
   _, _, resp = Cuba.call({})
 
   assert_response resp, ["Header\nThis is the actual content.\nFooter\n"]
+end
+
+test "overrides layout" do
+  Cuba.plugin Cuba::Render
+  Cuba.settings[:render][:views] = "./test/views"
+
+  Cuba.define do
+    on true do
+      res.write view("home", { name: "Agent Smith", title: "Home" }, "layout-alternative")
+    end
+  end
+
+  _, _, body = Cuba.call({})
+
+  assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
 end

--- a/test/views/layout-alternative.erb
+++ b/test/views/layout-alternative.erb
@@ -1,0 +1,2 @@
+<title>Alternative Layout: <%= title %></title>
+<%= content %>


### PR DESCRIPTION
Adds a Cuba.settings[:render][:layout] variable.
This lets you set different layouts for different applications.

```
Cuba.plugin Cuba::Render

class Admins < Cuba
  settings[:render][:layout] = "admins_layout"

  on default do
    # Now this will render the home view inside the admins_layout layout
    res.write view("home", content: "hello, world")
  end

end
```

This is useful when having a Guests and an Admin app, where you'd like to show different layouts depending on the context without needing to specify it in every `view` call.
