### PR TITLE
fix tests

### DIFF
--- a/test/render.rb
+++ b/test/render.rb
@@ -40,7 +40,7 @@ scope do
   test "view" do
     _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
 
-    assert_response body, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+    assert_response body, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n\n"]
   end
 
   test "partial with str as engine" do
@@ -64,7 +64,7 @@ scope do
 
     _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
 
-    assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+    assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n\n"]
   end
 end
 
@@ -100,7 +100,7 @@ test "simple layout support" do
 
   _, _, resp = Cuba.call({})
 
-  assert_response resp, ["Header\nThis is the actual content.\nFooter\n"]
+  assert_response resp, ["Header\nThis is the actual content.\n\nFooter\n"]
 end
 
 test "overrides layout" do
@@ -115,5 +115,5 @@ test "overrides layout" do
 
   _, _, body = Cuba.call({})
 
-  assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+  assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n\n"]
 end


### PR DESCRIPTION
Fix tests

since version 2.8, libxml2 -nokogiri's dependency- does not strip new lines after a closed tag

**Note:** 
Nokogiri's version 1.6.0
ruby 2.0.0

related [issue](https://github.com/vmg/redcarpet/issues/210)
