### PR TITLE
Take advantage of ruby 2.1's #def returns

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -186,7 +186,7 @@ class Cuba
 
   # @private Used internally by #on to ensure that SCRIPT_NAME and
   #          PATH_INFO are reset to their proper values.
-  def try
+  private def try
     script, path = env["SCRIPT_NAME"], env["PATH_INFO"]
 
     yield
@@ -194,9 +194,8 @@ class Cuba
   ensure
     env["SCRIPT_NAME"], env["PATH_INFO"] = script, path
   end
-  private :try
 
-  def consume(pattern)
+  private def consume(pattern)
     matchdata = env["PATH_INFO"].match(/\A\/(#{pattern})(\/|\z)/)
 
     return false unless matchdata
@@ -208,7 +207,6 @@ class Cuba
 
     captures.push(*vars)
   end
-  private :consume
 
   def match(matcher, segment = "([^\\/]+)")
     case matcher

--- a/lib/cuba/render.rb
+++ b/lib/cuba/render.rb
@@ -52,9 +52,8 @@ class Cuba
 
     # @private Used internally by #render to cache the
     #          Tilt templates.
-    def _cache
+    private def _cache
       Thread.current[:_cache] ||= Tilt::Cache.new
     end
-    private :_cache
   end
 end


### PR DESCRIPTION
From Ruby 2.1 onwards the def method returns a symbol created from the method's name, allowing us to avoid a bit of repetition when declaring private methods.

``` ruby
## Ruby 2.0 < 
def foo; end
private :foo

## Ruby 2.1 > 
private def foo; end
```

This pull request shouldn't be merged until cuba stops supporting Ruby versions prior to 2.1, so I expect it to never be merged in practice. 

I was super bored though.
