### PR TITLE
Use a less strict test for deleting cookies

### DIFF
--- a/test/cookie.rb
+++ b/test/cookie.rb
@@ -29,6 +29,6 @@ test "delete cookie" do
 
    _, headers, body = Cuba.call(env)
 
-   assert_equal "foo=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000",
+   assert /foo=; (max-age=0; )?expires=Thu, 01[ -]Jan[ -]1970 00:00:00 (-0000|GMT)/ =~
      headers["Set-Cookie"]
 end


### PR DESCRIPTION
My environment uses the following in this test:

"foo=; expires=Thu, 01-Jan-1970 00:00:00 GMT"

I'm guessing the test should still be considered passing in this
case, but if there is a reason to consider this a failure, it
should probably be fixed in the code.
