### PR TITLE
Support inline templates via a render :template_block option

### DIFF
--- a/lib/cuba/render.rb
+++ b/lib/cuba/render.rb
@@ -46,7 +46,13 @@ class Cuba
     #
     def render(template, locals = {}, options = {}, &block)
       _cache.fetch(template) {
-        Tilt.new(template, 1, options.merge(outvar: '@_output'))
+        if template_block = options[:template_block]
+          template_class = Tilt[settings[:render][:template_engine]]
+        else
+          template_class = Tilt
+        end
+
+        template_class.new(template, 1, options.merge(outvar: '@_output'), &template_block)
       }.render(self, locals, &block)
     end
 

--- a/test/render.rb
+++ b/test/render.rb
@@ -28,6 +28,11 @@ scope do
       on "about" do
         res.write partial("about", title: "About Cuba")
       end
+
+      on "inline" do
+        template = "Hello <%= name %>"
+        res.write render(template, {name: "Agent Smith"}, :template_block=>proc{template})
+      end
     end
   end
 
@@ -41,6 +46,12 @@ scope do
     _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
 
     assert_response body, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+  end
+
+  test "inline render" do
+    _, _, body = Cuba.call({ "PATH_INFO" => "/inline", "SCRIPT_NAME" => "/" })
+
+    assert_response body, ["Hello Agent Smith"]
   end
 
   test "partial with str as engine" do


### PR DESCRIPTION
In order for inline templates to work, two changes are necessary:

1) You need to pass a block when creating the template that
   returns the template content.

2) You have to specify the engine upfront, since it can no longer
   be inferred from the file name.

With this patch, if the template_block option is used, it is passed
to the template new method, using the default template engine.

This is easy to extend in the future to handle inline templates
that do not use the default template engine.
