### PR TITLE
Fix render tests if erubis is installed

### DIFF
--- a/test/render.rb
+++ b/test/render.rb
@@ -40,7 +40,7 @@ scope do
   test "view" do
     _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
 
-    assert_response body, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+    assert_response body.map{|s| s.strip}, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>"]
   end
 
   test "partial with str as engine" do
@@ -56,7 +56,7 @@ scope do
 
     _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
 
-    assert_response body, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n\n"]
+    assert_response body.map{|s| s.strip}, ["<title>Cuba: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>"]
   end
 
   test "custom default layout support" do
@@ -64,7 +64,7 @@ scope do
 
     _, _, body = Cuba.call({ "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" })
 
-    assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+    assert_response body.map{|s| s.strip}, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>"]
   end
 end
 
@@ -100,7 +100,7 @@ test "simple layout support" do
 
   _, _, resp = Cuba.call({})
 
-  assert_response resp, ["Header\nThis is the actual content.\nFooter\n"]
+  assert_response resp.map{|s| s.gsub(/\n+/, "\n")}, ["Header\nThis is the actual content.\nFooter\n"]
 end
 
 test "overrides layout" do
@@ -115,5 +115,5 @@ test "overrides layout" do
 
   _, _, body = Cuba.call({})
 
-  assert_response body, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>\n"]
+  assert_response body.map{|s| s.strip}, ["<title>Alternative Layout: Home</title>\n<h1>Home</h1>\n<p>Hello Agent Smith</p>"]
 end


### PR DESCRIPTION
Tilt automatically uses erubis to render erb if erubis is installed,
and the two handle whitespace slightly differently.
