### PR TITLE
Responds 404 if nested conditions are unmet.

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -5,6 +5,7 @@ class Cuba
   class Response
     attr_accessor :status
 
+    attr :body
     attr :headers
 
     def initialize(status = 200,
@@ -38,6 +39,8 @@ class Cuba
     end
 
     def finish
+      @status ||= @body.empty?? 404 : 200
+
       [@status, @headers, @body]
     end
 
@@ -180,7 +183,11 @@ class Cuba
       # are carried out by #consume.
       yield(*captures)
 
-      halt res.finish
+      if res.status == 200 and res.body.empty?
+        res.status = 404
+      end
+
+      halt(res.finish)
     end
   end
 

--- a/test/on.rb
+++ b/test/on.rb
@@ -103,9 +103,34 @@ test "responds 404 if conditions are not met" do
     end
   end
 
-  env = { "PATH_INFO" => "/home", "SCRIPT_NAME" => "/" }
-  status, _, resp = Cuba.call(env)
+  env = { "PATH_INFO" => "/notexists", "SCRIPT_NAME" => "/" }
+  status, _, body = Cuba.call(env)
 
   assert_equal 404, status
-  assert_response resp, []
+  assert body.empty?
+end
+
+test "responds 404 if nested conditions are not met" do
+  Cuba.define do
+    on get do
+      on root do
+        res.write("Should be unmet")
+      end
+    end
+
+    on default do
+      res.write("Should be unmet")
+    end
+  end
+
+  env = {
+    "REQUEST_METHOD" => "GET",
+    "PATH_INFO" => "/notexists",
+    "SCRIPT_NAME" => "/"
+  }
+
+  status, _, body = Cuba.call(env)
+
+  assert_equal 404, status
+  assert body.empty?
 end


### PR DESCRIPTION
Before:

``` ruby
Cuba.define do
  on get do
    on root do
      res.write("unmet")
    end
  end
end

# GET /notexists => 200
```

After:

``` ruby
Cuba.define do
  on get do
    on root do
      res.write("unmet")
    end
  end
end

# GET /notexists => 404
```

This solves the "tricky" behaviour explained in #27.
