### PR TITLE
Attempt to look up non-existing settings in parent classes (see #21)

### DIFF
--- a/test/settings.rb
+++ b/test/settings.rb
@@ -18,6 +18,22 @@ test "is inheritable and allows overriding" do
   assert_equal "baz", Admin.settings[:foo]
 end
 
+test "attempts to get absent settings from parent class" do
+  class User < Cuba; end
+  class PowerUser < User; end
+
+  Cuba.settings[:get_from_parent] = "x"
+
+  assert_equal nil, Cuba.settings[:does_not_exist]
+  assert_equal nil, User.settings[:absent]
+  assert_equal "x", User.settings[:get_from_parent]
+  assert_equal "x", PowerUser.settings[:get_from_parent]
+
+  Cuba.settings[:after_deepcloning] = "x"
+
+  assert_equal "x", User.settings[:after_deepcloning]
+end
+
 test do
   Cuba.settings[:hello] = "Hello World"
 


### PR DESCRIPTION
This fixes an issue where settings are added to Cuba.settings _after_ inheriting from `Cuba` are not picked up by the child classes. The problem is described in issue #21.

If a setting does not exist, settings are looked up in the settings Hash of the parent class using `Hash#default_proc`. The settings Hash is still deepcloned, so settings are still overridable.
