### PR TITLE
Updated CSRF code examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Here's an example of how to use it:
 require "cuba"
 require "cuba/safe"
 
+Cuba.use Rack::Session::Cookie, :secret => "__a_very_long_string__"
+
 Cuba.plugin Cuba::Safe
 
 Cuba.define do
@@ -382,13 +384,13 @@ among your meta tags. Here's an example that assumes you are using
 <!DOCTYPE html>
 <html>
   <head>
-    {{ this.csrf.meta_tag }}
+    {{ app.csrf.meta_tag }}
     ...
   </head>
   ...
   <body>
     <form action="/foo" method="POST">
-      {{ this.csrf.form_tag }}
+      {{ app.csrf.form_tag }}
       ...
     </form>
   ...


### PR DESCRIPTION
`{{ this.csrf.meta_tag }}` results in error:
```text
undefined local variable or method `this' for #<Binding:0x007f7db5b525b8>
```

Omitting `Cuba.use Rack::Session::Cookie, :secret => 'string'` results in error:
```text
undefined method `[]' for nil:NilClass
```

Updated the readme so these errors aren't encountered when following the examples.

```text
Gem versions:
cuba (3.4.0)
mote (1.1.3)
mote-render (1.1.0)
```