### PR TITLE
Freeze missing strings

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -2,8 +2,8 @@ require "rack"
 require "time"
 
 class Cuba
-  DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8"
-  CONTENT_TYPE = "Content-Type"
+  DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8".freeze
+  CONTENT_TYPE = "Content-Type".freeze
   EMPTY_STRING = "".freeze
   PATH_INFO = "PATH_INFO".freeze
   SCRIPT_NAME = "SCRIPT_NAME".freeze


### PR DESCRIPTION
Seems that [two lines](https://github.com/soveran/cuba/blob/master/lib/cuba.rb#L5-L6) were missed from [this commit](https://github.com/soveran/cuba/commit/eafa96e5192a417cf6ab0aa0a2a78bcc89bb95d7).