### PR TITLE
Add syntactic sugar for matching all HTTP methods

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -325,10 +325,16 @@ class Cuba
   #
   #   on post, "signup" do
   #   end
-  def get;    req.get?    end
-  def post;   req.post?   end
-  def put;    req.put?    end
-  def delete; req.delete? end
+  def get;     req.get?     end
+  def post;    req.post?    end
+  def put;     req.put?     end
+  def patch;   req.patch?   end
+  def delete;  req.delete?  end
+  def head;    req.head?    end
+  def options; req.options? end
+  def link;    req.link?    end
+  def unlink;  req.unlink?  end
+  def trace;   req.trace?   end
 
   # If you want to halt the processing of an existing handler
   # and continue it via a different handler.


### PR DESCRIPTION
Some less-known HTTP methods are not currently supported by Cuba. This patch fixes that.

Issue discussed in #77 