### PR TITLE
Make needed rack version flexible

### DIFF
--- a/cuba.gemspec
+++ b/cuba.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
-  s.add_dependency "rack", "~> 1.6.0"
+  s.add_dependency "rack", ">= 1.6.0"
   s.add_development_dependency "cutest"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "tilt"


### PR DESCRIPTION
Update rack dependency to follow a more flexible syntax which allows developers to switch to rack 2.0 if needed.

Tests run OK when using rack 2.0.1:

```
cuba > gem list | grep rack
rack (2.0.1)
cuba > make
cutest ./test/*.rb
..................................................................................................................................................
```