### PR TITLE
Fix Rack 2 deprecation warning

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -262,7 +262,7 @@ class Cuba
   #     # If not provided, username == "guest"
   #   end
   def param(key, default = nil)
-    value = req[key] || default
+    value = req.params[key] || default
 
     lambda { captures << value unless value.to_s.empty? }
   end


### PR DESCRIPTION
Since the Rack dependency version was relaxed in the gemspec, using Rack >= 2.0 will now show a deprecation warning. `Request#[]` was deprecated in https://github.com/rack/rack/pull/1069. 

Please check it out, thanks! 