### PR TITLE
Fix capturing symbol params

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -262,7 +262,7 @@ class Cuba
   #     # If not provided, username == "guest"
   #   end
   def param(key, default = nil)
-    value = req.params[key] || default
+    value = req.params[key.to_s] || default
 
     lambda { captures << value unless value.to_s.empty? }
   end


### PR DESCRIPTION
Call `to_s` when capturing params in order to keep compatibility with previous behavior.

See also https://github.com/soveran/cuba/pull/92