### PR TITLE
Backporting Syro Content-Type methods

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -10,6 +10,12 @@ class Cuba
   class Response
     LOCATION = "Location".freeze
 
+    module ContentType
+      HTML = "text/html".freeze        # :nodoc:
+      TEXT = "text/plain".freeze       # :nodoc:
+      JSON = "application/json".freeze # :nodoc:
+    end
+
     attr_accessor :status
 
     attr :body
@@ -36,6 +42,24 @@ class Cuba
       @length += s.bytesize
       @headers[Rack::CONTENT_LENGTH] = @length.to_s
       @body << s
+    end
+
+    # Write response body as text/plain
+    def text(str)
+      @headers[Rack::CONTENT_TYPE] = ContentType::TEXT
+      write(str)
+    end
+
+    # Write response body as text/html
+    def html(str)
+      @headers[Rack::CONTENT_TYPE] = ContentType::HTML
+      write(str)
+    end
+
+    # Write response body as application/json
+    def json(str)
+      @headers[Rack::CONTENT_TYPE] = ContentType::JSON
+      write(str)
     end
 
     def redirect(path, status = 302)

--- a/test/accept.rb
+++ b/test/accept.rb
@@ -30,3 +30,48 @@ test "tests don't fail when you don't specify an accept type" do
 
   assert_response body, ["Default action"]
 end
+
+test "accept HTML mimetype" do
+  Cuba.define do
+    on accept("text/html") do
+      res.write Cuba::Response::ContentType::HTML
+    end
+  end
+
+  env = { "HTTP_ACCEPT" => "text/html",
+          "SCRIPT_NAME" => "/", "PATH_INFO" => "/post" }
+
+   _, _, body = Cuba.call(env)
+
+  assert_response body, ["text/html"]
+end
+
+test "accept TEXT mimetype" do
+  Cuba.define do
+    on accept("text/plain") do
+      res.write Cuba::Response::ContentType::TEXT
+    end
+  end
+
+  env = { "HTTP_ACCEPT" => "text/plain",
+          "SCRIPT_NAME" => "/", "PATH_INFO" => "/post" }
+
+   _, _, body = Cuba.call(env)
+
+  assert_response body, ["text/plain"]
+end
+
+test "accept JSON mimetype" do
+  Cuba.define do
+    on accept("application/json") do
+      res.write Cuba::Response::ContentType::JSON
+    end
+  end
+
+  env = { "HTTP_ACCEPT" => "application/json",
+          "SCRIPT_NAME" => "/", "PATH_INFO" => "/get" }
+
+   _, _, body = Cuba.call(env)
+
+  assert_response body, ["application/json"]
+end


### PR DESCRIPTION
Hello I saw some interesting methods within Syro that could be useful and convenient within Cuba. And going off Syro's readme: 

>  In the future, some ideas of this library could be included in Cuba as well. 

I am making this pull request to add these methods into the Cuba project. 