### PR TITLE
Fix uppercase characters in headers

### DIFF
--- a/lib/cuba.rb
+++ b/lib/cuba.rb
@@ -10,7 +10,7 @@ class Cuba
   REGEXES = Hash.new { |h, pattern| h[pattern] = /\A\/(#{pattern})(\/|\z)/ }
 
   class Response
-    LOCATION = "Location".freeze
+    LOCATION = "location".freeze
 
     module ContentType
       HTML = "text/html".freeze        # :nodoc:

--- a/lib/cuba/render.rb
+++ b/lib/cuba/render.rb
@@ -13,7 +13,7 @@ class Cuba
     end
 
     def render(template, locals = {}, layout = settings[:render][:layout])
-      res.headers["Content-Type"] ||= "text/html; charset=utf-8"
+      res.headers["content-type"] ||= "text/html; charset=utf-8"
       res.write(view(template, locals, layout))
     end
 


### PR DESCRIPTION
Fixes Rack::Lint::LintError at /
uppercase character in header name: Location

Found when running the simple sample application - problem with res.redirect().
=)